### PR TITLE
Python extra req

### DIFF
--- a/get_python_requirements.sh
+++ b/get_python_requirements.sh
@@ -43,8 +43,7 @@ if [[ ! -f "$req_file" ]]; then
 fi
 
 # Remove commented and empty lines & loop through the requirements
-echo $VIRTUALENV
-grep -v '^#\|^$' $req_file | while read line
+grep -vE '^#|^$' $req_file | while read line
 do
     cmd="$pip_command install $line"
     echo $cmd

--- a/python.mk
+++ b/python.mk
@@ -30,9 +30,13 @@ endif
 python_dependencies: python_requirements.txt
 	$(PIP) install -r python_requirements.txt
 
-# Loop over the python_extra_requirements.txt file and install packages in order.
-# We did that because of dependencies bugs in pip and the packages are freaking big.
-# WARNING: order in python_extra_requirements.txt matters!!!
+# Loop over the python_extra_requirements.txt file and install packages in
+# order. We did that because the package "statsmodels" does not handle
+# dependencies that are not installed. For more information, see:
+# https://github.com/statsmodels/statsmodels/pull/1902
+# https://github.com/statsmodels/statsmodels/issues/1897
+#
+# WARNING: packages order in python_extra_requirements.txt matters!!!
 python_extra_dependencies: python_extra_requirements.txt python_dependencies	
 	jml-build/get_python_requirements.sh -c $(PIP) -r python_extra_requirements.txt 
 


### PR DESCRIPTION
Il va falloir également ajouter ou modifier le fichier python_extra_requirements.txt dans le repo du projet. Voici une liste de dépendances qui fonctionne pour installer ggplot :
numpy==1.8.1
scipy==0.14.0
openpyxl==1.6.1
pandas==0.14.0
patsy==0.2.1
ggplot==0.5.8
