### PR TITLE
allow library names as targets.

### DIFF
--- a/functions.mk
+++ b/functions.mk
@@ -306,6 +306,9 @@ $$(LIB_$(1)_SO):	$$(dir $$(LIB_$(1)_SO))/.dir_exists $$(OBJFILES_$(1)) $$(foreac
 	$$(if $(verbose_build),@echo $$(LINK_$(1)_COMMAND2),@echo $$(LIB_$(1)_BUILD_NAME) $$(LIB_$(1)_FILENAME))
 	@$$(LINK_$(1)_COMMAND2)
 
+$$(tmpLIBNAME): $(LIB)/$$(tmpLIBNAME)$$(so)
+.PHONY:	$$(tmpLIBNAME)
+
 LIB_$(1)_DEPS := $(LIB)/$$(tmpLIBNAME)$$(so)
 
 libraries: $(LIB)/$$(tmpLIBNAME)$$(so)


### PR DESCRIPTION
It was always pretty annoying that there was no easy target to build a library (eg. make build/x86_64/bin/libblah.so). This pull request rectifies that so you can now build a library by pre-pending lib to the library name declared in th make file (eg. make libblah). The lib prefix was added to avoid any name conflicts with executables (shouldn't really be an issue but better safe then sorry).

PR was recreated in the correct repo.

@jeremybarnes @jraby
