### PR TITLE
Force use of pip>=6.0: wheels and /etc/pip.conf

### DIFF
--- a/python.mk
+++ b/python.mk
@@ -27,8 +27,10 @@ PYTHON_EXECUTABLE ?= $(VIRTUALENV)/bin/python
 
 endif
 
+# We force use of pip>=6.0 for wheel support and system wide pip.conf
 python_dependencies:
 	@if [ -f python_requirements.txt ]; then \
+		$(PIP) install -U pip>=6.0; \
 		$(PIP) install -r python_requirements.txt; \
 	fi
 

--- a/python.mk
+++ b/python.mk
@@ -6,6 +6,9 @@ PYTHON_VERSION ?= $(PYTHON_VERSION_DETECTED)
 PYTHON_INCLUDE_PATH ?= $(VIRTUALENV)/include/python$(PYTHON_VERSION)
 PYTHON ?= python$(PYTHON_VERSION)
 PIP ?= pip
+# We force use of pip>=6.0 for wheel support and system wide pip.conf
+# Pinned version to avoid unexpected upgrades
+PIP_PKG ?= pip==6.0.8
 PYFLAKES ?= true
 
 PYTHON_PURE_LIB_PATH ?= $(BIN)
@@ -27,10 +30,9 @@ PYTHON_EXECUTABLE ?= $(VIRTUALENV)/bin/python
 
 endif
 
-# We force use of pip>=6.0 for wheel support and system wide pip.conf
 python_dependencies:
 	@if [ -f python_requirements.txt ]; then \
-		$(PIP) install -U pip>=6.0; \
+		$(PIP) install -U $(PIP_PKG); \
 		$(PIP) install -r python_requirements.txt; \
 	fi
 

--- a/python.mk
+++ b/python.mk
@@ -6,10 +6,9 @@ PYTHON_VERSION ?= $(PYTHON_VERSION_DETECTED)
 PYTHON_INCLUDE_PATH ?= $(VIRTUALENV)/include/python$(PYTHON_VERSION)
 PYTHON ?= python$(PYTHON_VERSION)
 PIP ?= pip
-# We force use of pip>=6.0 for wheel support and system wide pip.conf
-# Pinned version to avoid unexpected upgrades
-PIP_PKG ?= pip==6.0.8
 PYFLAKES ?= true
+# Override this to run a cmd before installing python_requirements.txt
+PYTHON_DEPENDENCIES_PRE_CMD ?= true  
 
 PYTHON_PURE_LIB_PATH ?= $(BIN)
 PYTHON_PLAT_LIB_PATH ?= $(BIN)
@@ -31,8 +30,8 @@ PYTHON_EXECUTABLE ?= $(VIRTUALENV)/bin/python
 endif
 
 python_dependencies:
-	@if [ -f python_requirements.txt ]; then \
-		$(PIP) install -U $(PIP_PKG); \
+	if [ -f python_requirements.txt ]; then \
+		$(PYTHON_DEPENDENCIES_PRE_CMD); \
 		$(PIP) install -r python_requirements.txt; \
 	fi
 


### PR DESCRIPTION
I need this for 2 reasons:
  - support for wheel packages (easy binary distribution of packages)
  - support for /etc/pip.conf (to control which PyPI server or alternate mirror is used globally)

There's a downside to it however, in the current implementation, pip will always be upgraded to the latest stable version (currently `6.0.8`)

Opinion on this? Should be pin it to a known good version and crank it manually when required?

cc @jeremybarnes  @nicolaskruchten @FinchPowers 