### PR TITLE
makefile dependency cleanup

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -92,24 +92,25 @@ DOCKER_TAG:= $(shell whoami)_latest
 
 #docker_%:	$(TMPBIN)/%.iid
 
-altroot_prep_%: % $(DOCKER_GLOBAL_DEPS) $(DOCKER_TARGET_DEPS)
-	@BUILD=$(BUILD) bash $(DOCKER_GET_REVISION_SCRIPT) $(<) > $(TMPBIN)/$(<).rid $(if $(DOCKER_ALLOW_DIRTY), || true,)
-	echo "revision" `cat $(TMPBIN)/$(<).rid`
-	@echo "Building $(<) for use within docker"
-	make TMPBIN=$(TMPBIN) LIB=$(TMPBIN)/docker-$(<)/opt/lib BIN=$(TMPBIN)/docker-$(<)/opt/bin ALTROOT=$(TMPBIN)/docker-$(<) $(<)
+altroot_prep_%: $(DOCKER_GLOBAL_DEPS) $(DOCKER_TARGET_DEPS)
+	@BUILD=$(BUILD) bash $(DOCKER_GET_REVISION_SCRIPT) $(*) > $(TMPBIN)/$(*).rid $(if $(DOCKER_ALLOW_DIRTY), || true,)
+	echo "revision" `cat $(TMPBIN)/$(*).rid`
+	@echo "Building $(*) for use within docker"
+	make TMPBIN=$(TMPBIN) LIB=$(TMPBIN)/docker-$(*)/opt/lib BIN=$(TMPBIN)/docker-$(*)/opt/bin ALTROOT=$(TMPBIN)/docker-$(*) $(*)
 
-docker_%: % $(DOCKER_GLOBAL_DEPS) $(DOCKER_TARGET_DEPS)
-	make altroot_prep_$(<)
+docker_%: $(DOCKER_GLOBAL_DEPS) $(DOCKER_TARGET_DEPS)
+	make altroot_prep_$(*)
 	@echo "Creating container"
-	@rm -f $(TMPBIN)/$(<).cid
-	docker run -cidfile $(TMPBIN)/$(<).cid -v `pwd`:/tmp/build $(DOCKER_BASE_IMAGE) sh /tmp/build/$(JML_BUILD)/docker_install_inside_container.sh /tmp/build/$(TMPBIN)/docker-$(<) $(if $(DOCKER_POST_INSTALL_SCRIPT),/tmp/build/$(DOCKER_POST_INSTALL_SCRIPT))
-	cat $(TMPBIN)/$(<).cid
-	echo docker commit `cat $(TMPBIN)/$(<).cid` $(DOCKER_REGISTRY)$(DOCKER_USER)$(<):`cat $(TMPBIN)/$(<).rid`
-	docker commit $(DOCKER_COMMIT_ARGS) `cat $(TMPBIN)/$(<).cid` $(DOCKER_REGISTRY)$(DOCKER_USER)$(<):`cat $(TMPBIN)/$(<).rid` > $(TMPBIN)/$<.iid && cat $(TMPBIN)/$<.iid
-	$(if $(DOCKER_TAG),docker tag `cat $(TMPBIN)/$(<).iid` $(DOCKER_REGISTRY)$(DOCKER_USER)$(<):$(DOCKER_TAG))
-	$(if $(DOCKER_PUSH),docker tag `cat $(TMPBIN)/$(<).iid` $(DOCKER_REGISTRY)$(DOCKER_USER)$(<):latest)
-	@docker rm `cat $(TMPBIN)/$(<).cid`
-	$(if $(DOCKER_PUSH),$(if $(DOCKER_TAG), docker push $(DOCKER_REGISTRY)$(DOCKER_USER)$(<):$(DOCKER_TAG)))
-	$(if $(DOCKER_PUSH),docker push $(DOCKER_REGISTRY)$(DOCKER_USER)$(<):latest)
-	@echo $(COLOR_WHITE)Created $(if $(DOCKER_PUSH),and pushed )$(COLOR_BOLD)$(DOCKER_REGISTRY)$(DOCKER_USER)$(<):`cat $(TMPBIN)/$(<).rid`$(COLOR_RESET) as image $(COLOR_WHITE)$(COLOR_BOLD)`cat $(TMPBIN)/$<.iid`$(COLOR_RESET)
+	@rm -f $(TMPBIN)/$(*).cid
+	docker run -cidfile $(TMPBIN)/$(*).cid -v `pwd`:/tmp/build $(DOCKER_BASE_IMAGE) sh /tmp/build/$(JML_BUILD)/docker_install_inside_container.sh /tmp/build/$(TMPBIN)/docker-$(*) $(if $(DOCKER_POST_INSTALL_SCRIPT),/tmp/build/$(DOCKER_POST_INSTALL_SCRIPT))
+	cat $(TMPBIN)/$(*).cid
+	echo docker commit `cat $(TMPBIN)/$(*).cid` $(DOCKER_REGISTRY)$(DOCKER_USER)$(*):`cat $(TMPBIN)/$(*).rid`
+	docker commit $(DOCKER_COMMIT_ARGS) `cat $(TMPBIN)/$(*).cid` $(DOCKER_REGISTRY)$(DOCKER_USER)$(*):`cat $(TMPBIN)/$(*).rid` > $(TMPBIN)/$(*).iid && cat $(TMPBIN)/$(*).iid
+	$(if $(DOCKER_TAG),docker tag `cat $(TMPBIN)/$(*).iid` $(DOCKER_REGISTRY)$(DOCKER_USER)$(*):$(DOCKER_TAG))
+	$(if $(DOCKER_PUSH),docker tag `cat $(TMPBIN)/$(*).iid` $(DOCKER_REGISTRY)$(DOCKER_USER)$(*):latest)
+	@docker rm `cat $(TMPBIN)/$(*).cid`
+	$(if $(DOCKER_PUSH),$(if $(DOCKER_TAG), docker push $(DOCKER_REGISTRY)$(DOCKER_USER)$(*):$(DOCKER_TAG)))
+	$(if $(DOCKER_PUSH),docker push $(DOCKER_REGISTRY)$(DOCKER_USER)$(*):latest)
+	@echo $(COLOR_WHITE)Created $(if $(DOCKER_PUSH),and pushed )$(COLOR_BOLD)$(DOCKER_REGISTRY)$(DOCKER_USER)$(*):`cat $(TMPBIN)/$(*).rid`$(COLOR_RESET) as image $(COLOR_WHITE)$(COLOR_BOLD)`cat $(TMPBIN)/$(*).iid`$(COLOR_RESET)
+
 


### PR DESCRIPTION
this is a 2 part PR,  first the dependencies for docker_% target are reworked to avoid building the real target twice (once with regular BIN,LIB,ALTROOT variables and once with docker ones)

Second 2 functions are added to ease the writing rules to add files to a docker container.